### PR TITLE
Corrected the callback delegate for changing pages.

### DIFF
--- a/DirectOutputCSharpWrapper/DirectOutput.cs
+++ b/DirectOutputCSharpWrapper/DirectOutput.cs
@@ -57,7 +57,7 @@ namespace DirectOutputCSharpWrapper {
 		public delegate void EnumerateCallback(IntPtr device, IntPtr target);
 		public delegate void DeviceCallback(IntPtr device, bool added, IntPtr target);
 		public delegate void SoftButtonCallback(IntPtr device, UInt32 buttons, IntPtr target);
-		public delegate void PageCallback(IntPtr device, bool activated, IntPtr target);
+		public delegate void PageCallback(IntPtr device, Int32 page, bool activated, IntPtr target);
 
 		// Library functions
 		private delegate HResult DirectOutput_Initialize([MarshalAsAttribute(UnmanagedType.LPWStr)] String appName);


### PR DESCRIPTION
This matches the docs from http://driveragent.com/c/archive/1f36b7e8/image/3-1-6/Saitek-X52-Pro-Flight-Controller?PHPSESSID=tv0476qgdmhs921vgjv1td4k91#DirectOutput_Device_Callback and doesn't cause an "Access violation" when used. Thanks!